### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -1,5 +1,7 @@
 name: GitHub Actions Demo
 run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
+permissions:
+  contents: read
 on: [push]
 jobs:
   Explore-GitHub-Actions:


### PR DESCRIPTION
Potential fix for [https://github.com/Alcheri/WorldTime/security/code-scanning/2](https://github.com/Alcheri/WorldTime/security/code-scanning/2)

In general, the fix is to add an explicit `permissions:` block that grants only the minimal required scopes to the `GITHUB_TOKEN`. For this workflow, all steps are read‑only (checkout, echo, `ls`), so `contents: read` is sufficient. This block can be set at the workflow root (applies to all jobs) or at the job level; adding it at the root is simplest here and does not change existing behavior beyond restricting unnecessary write permissions.

The best fix without changing existing functionality is to add a root‑level `permissions:` section after the `run-name:` (or `name:`) key in `.github/workflows/github-actions-demo.yml`:

```yaml
permissions:
  contents: read
```

No imports or additional definitions are needed, because this is a YAML workflow configuration only. This change documents the intended minimal permissions and ensures they remain constrained even if repository defaults change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
